### PR TITLE
add allowed-origins stuff

### DIFF
--- a/resources/leiningen/new/kraken_http_api/PROJECT@.service.template
+++ b/resources/leiningen/new/kraken_http_api/PROJECT@.service.template
@@ -27,7 +27,7 @@ ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} --restart=always \
   --link rabbitmq:rabbitmq \
   --link wildfly:wildfly \
-  --env FAKE_ENV_VAR=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/{{name}}/fake/env/var?raw) \
+  --env ALLOWED_ORIGINS=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/{{name}}/allowed-origins?raw) \
   ${DOCKER_REPO}:${VERSION}'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}

--- a/resources/leiningen/new/kraken_http_api/README.md
+++ b/resources/leiningen/new/kraken_http_api/README.md
@@ -4,25 +4,19 @@ TODO: Add description
 
 ## Configuration
 
-### New config
-
-New configuration on this app should be done in four steps:
-
-1. Add a configuration to the `resources/config.edn` file, using
-   `#resource-config/env` tagged literals for environment variables.
-2. Add the env var to the `{{name}}@.service.template` docker run
-   command, pulling in the value from Consul.
-   `--env FAKE_ENV_VAR=$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/{{name}}/fake/env/var?raw)`
-3. Set up the value in Consul.
-4. Add them to the README.md (this file) in the Running with
-   docker-compose section as well as documented in the existing config
-   section.
-
-Keys in Consul should be appropriately namespaced, preferably under {{name}}.
-
-### Existing config
-
 TODO: Add {{name}} specific configuration.
+
+* ALLOWED_ORIGINS
+    * This env var controls the cross-origin resource sharing (CORS) settings.
+    * It should be set to one of the following:
+        * `:all` to allow requests from any origin
+        * an EDN seq of allowed origin strings
+        * an EDN map containing the following keys and values
+            * :allowed-origins - sequence of strings
+            * :creds - true or false, indicates whether client is allowed to send credentials
+            * :max-age - a long, indicates the number of seconds a client should cache the response from a preflight request
+            * :methods - a string, indicates the accepted HTTP methods.  Defaults to "GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS"
+    * For example: `ALLOWED_ORIGINS=["http://foo.example.com" "http://bar.example.com"]`
 
 ## Usage
 

--- a/resources/leiningen/new/kraken_http_api/config.edn
+++ b/resources/leiningen/new/kraken_http_api/config.edn
@@ -1,4 +1,6 @@
-{:server {:hostname "0.0.0.0" :port 8080}
+{:server {:hostname "0.0.0.0"
+          :port 8080
+          :allowed-origins #resource-config/edn #resource-config/env "ALLOWED_ORIGINS"}
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
             :queues {"{{name}}.ok" {:exclusive false :durable true :auto-delete false}}}}

--- a/resources/leiningen/new/kraken_http_api/docker-compose.yml
+++ b/resources/leiningen/new/kraken_http_api/docker-compose.yml
@@ -3,6 +3,8 @@ app:
   links:
     - rabbitmq
     - wildfly
+  environment:
+    ALLOWED_ORIGINS: :all
 wildfly:
   image: quay.io/democracyworks/wildfly:8.2.0.Final
   links:

--- a/resources/leiningen/new/kraken_http_api/service.clj
+++ b/resources/leiningen/new/kraken_http_api/service.clj
@@ -31,6 +31,9 @@
    ::bootstrap/router :linear-search
    ::bootstrap/routes routes
    ::bootstrap/resource-path "/public"
+   ::bootstrap/allowed-origins (if (= :all (config [:server :allowed-origins]))
+                                 (constantly true)
+                                 (config [:server :allowed-origins]))
    ::bootstrap/host (config [:server :hostname])
    ::bootstrap/type :immutant
    ::bootstrap/port (config [:server :port])})


### PR DESCRIPTION
We found we needed this in the 2 deployed http-api components, and I
think we'll need it in all of them going forward.
