### PR TITLE
Update deps & things and add bifrost

### DIFF
--- a/resources/leiningen/new/kraken_http_api/docker-compose.yml
+++ b/resources/leiningen/new/kraken_http_api/docker-compose.yml
@@ -6,7 +6,7 @@ app:
   environment:
     ALLOWED_ORIGINS: :all
 wildfly:
-  image: quay.io/democracyworks/wildfly:8.2.0.Final
+  image: quay.io/democracyworks/wildfly:8.2.1.Final-debug
   links:
     - rabbitmq
   ports:

--- a/resources/leiningen/new/kraken_http_api/project.clj
+++ b/resources/leiningen/new/kraken_http_api/project.clj
@@ -22,7 +22,8 @@
                  [democracyworks/pedestal-toolbox "0.6.2"]
                  [org.immutant/web "2.1.1"]
                  [io.pedestal/pedestal.immutant "0.4.1"]
-                 [org.immutant/core "2.1.1"]]
+                 [org.immutant/core "2.1.1"]
+                 [democracyworks/bifrost "0.1.4"]]
   :plugins [[lein-immutant "2.1.0"]]
   :main ^:skip-aot {{name}}.server
   :target-path "target/%s"

--- a/resources/leiningen/new/kraken_http_api/project.clj
+++ b/resources/leiningen/new/kraken_http_api/project.clj
@@ -6,27 +6,24 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [turbovote.resource-config "0.2.0"]
-                 [com.novemberain/langohr "3.3.0"]
-                 [prismatic/schema "0.4.4"]
+                 [com.novemberain/langohr "3.4.1"]
+                 [prismatic/schema "1.0.3"]
                  [ch.qos.logback/logback-classic "1.1.3"]
 
                  ;; core.async has to come before pedestal or kehaar.wire-up will
                  ;; not compile. Something to do with the try-catch in
-                 ;; kehaar.core/go-handler.
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 ;; kehaar.core/go-handler. (This may not be true anymore in
+                 ;; core.async 0.2.x; need to test.)
+                 [org.clojure/core.async "0.2.374"]
                  [democracyworks/kehaar "0.5.0"]
-                 
-                 [io.pedestal/pedestal.service "0.4.0"]
-                 [io.pedestal/pedestal.service-tools "0.4.0"]
-                 [democracyworks/pedestal-toolbox "0.6.2"]
 
-                 ;; this has to go before pedestal.immutant
-                 ;; until this is fixed:
-                 ;; https://github.com/pedestal/pedestal/issues/33
-                 [org.immutant/web "2.0.2"]
-                 [io.pedestal/pedestal.immutant "0.4.0"]
-                 [org.immutant/core "2.0.2"]]
-  :plugins [[lein-immutant "2.0.0"]]
+                 [io.pedestal/pedestal.service "0.4.1"]
+                 [io.pedestal/pedestal.service-tools "0.4.1"]
+                 [democracyworks/pedestal-toolbox "0.6.2"]
+                 [org.immutant/web "2.1.1"]
+                 [io.pedestal/pedestal.immutant "0.4.1"]
+                 [org.immutant/core "2.1.1"]]
+  :plugins [[lein-immutant "2.1.0"]]
   :main ^:skip-aot {{name}}.server
   :target-path "target/%s"
   :uberjar-name "{{name}}.jar"

--- a/resources/leiningen/new/kraken_http_api/service.clj
+++ b/resources/leiningen/new/kraken_http_api/service.clj
@@ -8,7 +8,10 @@
             [pedestal-toolbox.params :refer :all]
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
-            [clojure.core.async :refer [chan go alt! timeout]]))
+            [clojure.core.async :refer [go alt! timeout]]
+            [bifrost.core :as bifrost]
+            [bifrost.interceptors :as bifrost.i]
+            [{{name}}.channels :as channels]))
 
 (def ping
   (interceptor


### PR DESCRIPTION
We're using bifrost in our all of our production HTTP API gateways now, and it seems to be doing its job well. So this PR adds it to the lein template. It also updates the dependencies, docker-compose images, etc.
